### PR TITLE
将课程表示为循环事件并添加正确的时间戳

### DIFF
--- a/json_version.py
+++ b/json_version.py
@@ -39,20 +39,16 @@ for c in x['studentTableVm']['activities']:
     sMin = int(c['startDate'].split(':')[1])
     eHour=int(c['endDate'].split(':')[0])
     eMin = int(c['endDate'].split(':')[1])
-    weeks=[]
-    if status==0:
-        weeks.extend(range(startWeek-1,endWeek))
-    else:
-        weeks.extend(range(startWeek-1, endWeek ,2))
-    for i in weeks:
-        event = Event()
-        event.add('summary', summary)
-        event.add('location', location)
-        event.add('description', description)
-        event.add('dtstart',FIRST+timedelta(days=weekday,weeks=i,hours=sHour,minutes=sMin))
-        event.add('dtend', FIRST+timedelta(days=weekday,weeks=i,hours=eHour,minutes=eMin))
-        event.add('dtstamp', FIRST+timedelta(days=weekday,weeks=i,hours=sHour,minutes=sMin))
-        cal.add_component(event)
+    event = Event()
+    event.add('summary', summary)
+    event.add('location', location)
+    event.add('description', description)
+    event.add('dtstart',FIRST+timedelta(days=weekday,weeks=startWeek-1,hours=sHour,minutes=sMin))
+    event.add('dtend', FIRST+timedelta(days=weekday,weeks=startWeek-1,hours=eHour,minutes=eMin))
+    event.add('dtstamp', datetime.utcnow())
+    interval = 2 if status else 1
+    event.add('rrule', {'freq': 'weekly', 'interval': interval, 'count': (endWeek - startWeek) // interval + 1})
+    cal.add_component(event)
 f = open('example.ics', 'wb')
 f.write(cal.to_ical())
 f.close()


### PR DESCRIPTION
1. 原脚本对于所有课程在上课的每一周各创建一个事件，不方便修改和管理。重写后只需对于每一课程（的每一时段）各创建一个循环事件。（效果图由@JiangGua提供）

![mmexport1578985028868](https://user-images.githubusercontent.com/47456195/72321256-65fde880-36de-11ea-94d2-5a586f07f64b.jpg)

2. 根据RFC 2445，[DTSTAMP](https://www.kanzaki.com/docs/ical/dtstamp.html)应为相应的iCalendar对象（VEVENT等）在UTC下的创建时间。此commit将为事件加上正确的时间戳。